### PR TITLE
Update README: remove '--save-dev' from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In this document:
 Install the package as a dependency of your Stencil theme:
 
 ```
-npm install brandlabs-bigcommerce-wishlist --save-dev
+npm install brandlabs-bigcommerce-wishlist
 ```
 
 ### Required template


### PR DESCRIPTION
This is not a dev dependency of a Stencil theme. This package's code actually runs from the theme's front-end.